### PR TITLE
Reintroduce key parameter to transfer_store

### DIFF
--- a/git-annex-remote-zenodo
+++ b/git-annex-remote-zenodo
@@ -209,7 +209,7 @@ class ZenodoRemote(ExportRemote):
         self.query('get', url, "get_latest_draft")
         return newest_id
 
-    def transfer_store(self, path):
+    def transfer_store(self, key, path):
         # store the file in `filename` to a unique location derived from `key`
         # raise RemoteError if the file couldn't be stored
         r = self.query('get', self.url, "transfer_store")
@@ -341,7 +341,7 @@ class ZenodoRemote(ExportRemote):
     def transferexport_store(self, key, local_file, remote_file):
         # store the file located at `local_file` to `remote_file` on the remote
         # raise RemoteError if the file couldn't be stored
-        return self.transfer_store(local_file)
+        return self.transfer_store(key, local_file)
 
     def transferexport_retrieve(self, key, local_file, remote_file):
         # get the file located at `remote_file` from the remote and store it to `local_file`


### PR DESCRIPTION
It was, maybe accidentally, removed in 117f4e4, but the annex-remote package relies on passing the key parameter to transfer_store. See
https://github.com/Lykos153/AnnexRemote/blob/309f619e2f533373280fb9aa6cac45cbc1ee4842/annexremote/annexremote.py#L613 for the code, and below for the traceback:
```
[2024-08-19 11:15:42.307829165] (Remote.External)   File "/home/adina/env/datalad/lib/python3.12/site-packages/annexremote/annexremote.py", line 613, in do_TRANSFER
[2024-08-19 11:15:42.307945204] (Annex.ExternalAddonProcess) /home/adina/repos/git-annex-remote-zenodo/git-annex-remote-zenodo[1] --> DEBUG     func(key, file_)
[2024-08-19 11:15:42.308060474] (Remote.External)     func(key, file_)
[2024-08-19 11:15:42.308162839] (Annex.ExternalAddonProcess) /home/adina/repos/git-annex-remote-zenodo/git-annex-remote-zenodo[1] --> DEBUG TypeError: ZenodoRemote.transfer_store() takes 2 positional arguments but 3 were given
```